### PR TITLE
v1.18.0 — Updated documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.18.0
+------------------------------
+*August 29, 2018*
+
+### Added
+- Page Banner documentation.
+- Icon documentation.
+- Ability to specify a visual docs demo CSS class.
+- Docs visual spacing bottom CSS class.
+
+### Changed
+- Reordered component subnav items.
+- Tweaks to the sentence order of the cards and badges documentation.
+- Component index split across three columns.
+- Menu template using new `je-pagebanner` partial.
+- Updated project dependencies.
+
+
 v1.17.0
 ------------------------------
 *August 28, 2018*

--- a/assets/src/scss/components/_demoBlock.scss
+++ b/assets/src/scss/components/_demoBlock.scss
@@ -33,9 +33,14 @@
         padding: spacing(x5) spacing(x5);
         position: relative;
     }
+        .demo-visual--spacingBottom {
+            padding-bottom: 160px;
+        }
+
         .demo-visual-bottomSpacer {
             height: 200px;
         }
+
         .demo-visual-logOutput {
             height: 300px;
         }

--- a/assets/src/scss/components/_demoBlock.scss
+++ b/assets/src/scss/components/_demoBlock.scss
@@ -35,14 +35,10 @@
     }
         .demo-visual--spacingBottom {
             padding-bottom: 160px;
-        }
 
-        .demo-visual-bottomSpacer {
-            height: 200px;
-        }
-
-        .demo-visual-logOutput {
-            height: 300px;
+            @include media('<mid') {
+                padding-bottom: spacing(x5);
+            }
         }
 
     .demo-code {

--- a/docs/src/templates/includes/components/core/je-pageBanner.hbs
+++ b/docs/src/templates/includes/components/core/je-pageBanner.hbs
@@ -1,0 +1,7 @@
+<div class="c-pageBanner c-pageBanner--negativeBottom--aboveMid">
+    <picture>
+        <source class="c-pageBanner-img" media="(min-width: 860px)" srcset="{{baseUrl}}/assets/img/examples/kebabs--wide.jpg" data-ft="restaurant-level-image--wide">
+        <source class="c-pageBanner-img" media="(min-width: 600px)" srcset="{{baseUrl}}/assets/img/examples/kebabs--mid.jpg" data-ft="restaurant-level-image--mid">
+        <img class="c-pageBanner-img" srcset="{{baseUrl}}/assets/img/examples/kebabs--narrow.jpg" alt="" data-ft="restaurant-level-image--narrow" >
+    </picture>
+</div>

--- a/docs/src/templates/includes/documentation-components/demo-block.hbs
+++ b/docs/src/templates/includes/documentation-components/demo-block.hbs
@@ -1,5 +1,5 @@
 <div class="demo">
-    <div class="demo-visual">
+    <div class="demo-visual {{demoVisualCssClass}}">
         <h4 class="demo-title">Example</h4>
         {{> @partial-block }}
     </div>

--- a/docs/src/templates/includes/documentation-components/subnavs/subnav--sidebar.hbs
+++ b/docs/src/templates/includes/documentation-components/subnavs/subnav--sidebar.hbs
@@ -15,47 +15,45 @@
 {{/is}}
 
 {{#is navsub 'ui-components'}}
-<!-- subnav for Styleguide > UI Components -->
+    <!-- subnav for Styleguide > Objects -->
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/buttons" class="{{#is navactive 'buttons'}} is-active{{/is}}">Buttons</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/checkboxes" class="{{#is navactive 'checkboxes'}} is-active{{/is}}">Checkboxes</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/radio-buttons" class="{{#is navactive 'radio-buttons'}} is-active{{/is}}">Radio Buttons</a></li>
+
+    <!-- subnav for Styleguide > Components -->
     <li><a href="{{ baseUrl }}/styleguide/ui-components/headers/" class="{{#is navactive 'headers'}} is-active{{/is}}">Headers</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/footers/" class="{{#is navactive 'footers'}} is-active{{/is}}">Footers</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/breadcrumbs" class="{{#is navactive 'breadcrumbs'}} is-active{{/is}}">Breadcrumbs</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/grid" class="is-incomplete {{#is navactive 'ui-grid'}} is-active{{/is}}">Grid</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/buttons" class="{{#is navactive 'buttons'}} is-active{{/is}}">Buttons</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/cards" class="{{#is navactive 'cards'}} is-active{{/is}}">Cards</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/badges" class="{{#is navactive 'badges'}} is-active{{/is}}">Badges</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/pagination" class="is-incomplete {{#is navactive 'pagination'}} is-active{{/is}}">Pagination</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/icons" class="is-incomplete {{#is navactive 'ui-icons'}} is-active{{/is}}">Icons</a></li>
-
-        <!-- title here - custom JE components -->
     <li><a href="{{ baseUrl }}/styleguide/ui-components/custom/star-ratings" class="{{#is navactive 'star-ratings'}} is-active{{/is}}">Star Ratings</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/custom/tooltip" class="is-incomplete {{#is navactive 'tooltip'}} is-active{{/is}}">Tooltip</a></li>
-
     <li><a href="{{ baseUrl }}/styleguide/ui-components/listings" class="{{#is navactive 'listings'}} is-active{{/is}}">Listings</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/mediaElement" class="{{#is navactive 'media-element'}} is-active{{/is}}">Media Element</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/icons" {{#is navactive 'ui-icons'}} is-active{{/is}}">Icons</a></li>
+
+    <!-- subnav for Styleguide > Optional Components -->
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/cards" class="{{#is navactive 'cards'}} is-active{{/is}}">Cards</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/badges" class="{{#is navactive 'badges'}} is-active{{/is}}">Badges</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/page-banner" class="{{#is navactive 'pagebanner'}} is-active{{/is}}">Page Banner</a></li>
+
+    <!-- subnav for Styleguide > To Do -->
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/grid" class="is-incomplete {{#is navactive 'ui-grid'}} is-active{{/is}}">Grid</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/pagination" class="is-incomplete {{#is navactive 'pagination'}} is-active{{/is}}">Pagination</a></li>
+
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/custom/tooltip" class="is-incomplete {{#is navactive 'tooltip'}} is-active{{/is}}">Tooltip</a></li>
+
     <li><a href="{{ baseUrl }}/styleguide/ui-components/custom/cookie-banner" class="is-incomplete {{#is navactive 'cookie-banner'}} is-active{{/is}}">Cookie Banner</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/custom/loaders" class="is-incomplete {{#is navactive 'loaders'}} is-active{{/is}}">Loaders</a></li>
 
     <li><a href="{{ baseUrl }}/styleguide/ui-components/hero-images" class="is-incomplete {{#is navactive 'hero-images'}} is-active{{/is}}">Hero Images</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/search-modules" class="is-incomplete {{#is navactive 'search-modules'}} is-active{{/is}}">Search Modules</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/menu-styles" class="is-incomplete {{#is navactive 'menu-styles'}} is-active{{/is}}">Menu Styles</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/linktext" class="is-incomplete {{#is navactive 'linktext'}} is-active{{/is}}">Links / Active Text</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/basket" class="is-incomplete {{#is navactive 'basket'}} is-active{{/is}}">Basket UI</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/error-pages" class="is-incomplete {{#is navactive 'error-pages'}} is-active{{/is}}">Error Pages</a></li>
 
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/restaurant-badges" class="is-incomplete {{#is navactive 'restaurant-badges'}} is-active{{/is}}">Restaurant Badges</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/line-breaks" class="is-incomplete {{#is navactive 'line-breaks'}} is-active{{/is}}">Line Breaks</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/app-icons" class="is-incomplete {{#is navactive 'app-icons'}} is-active{{/is}}">App Tiles &amp; Favicon</a></li>
 
-        <!-- title here - Navigation Elements -->
-
-        <!-- title here - Form Elements -->
     <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/" class="is-incomplete {{#is navactive 'forms'}} is-active{{/is}}">Forms</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/checkboxes" class="{{#is navactive 'checkboxes'}} is-active{{/is}}">Checkboxes</a></li>
-    <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/radio-buttons" class="{{#is navactive 'radio-buttons'}} is-active{{/is}}">Radio Buttons</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/messaging" class="is-incomplete {{#is navactive 'messaging'}} is-active{{/is}}">Error &amp; Success Messages</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/forms/drop-downs" class="is-incomplete {{#is navactive 'drop-downs'}} is-active{{/is}}">Drop down menus</a></li>
-
-    <!-- title here - Experiments -->
 {{/is}}
 
 

--- a/docs/src/templates/pages/styleguide/ui-components/badges.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/badges.hbs
@@ -8,9 +8,9 @@ navsub: ui-components
 navactive: badges
 ---
 
-<p><em>The <code>badge</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include badge();</code> into your SCSS dependencies file.</em></p>
-
 <p>Badges can be used to display small pieces of information.</p>
+
+<p><em>The <code>badge</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include badge();</code> into your SCSS dependencies file.</em></p>
 
 <h2 class="sg-sectionHeading">Default Badge – <code>.c-badge</code></h2>
 {{#>demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-components/cards.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/cards.hbs
@@ -8,9 +8,9 @@ navsub: ui-components
 navactive: cards
 ---
 
-<p><em>The <code>card</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include card();</code> into your SCSS dependencies file.</em></p>
-
 <p>Cards are simple content containers. They can be used in a variety of different ways such as separating sections of a page or wrapping content.</p>
+
+<p><em>The <code>card</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include card();</code> into your SCSS dependencies file.</em></p>
 
 <h2 class="sg-sectionHeading">Default Card – <code>.c-card</code></h2>
 {{#>demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-components/index.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/index.hbs
@@ -11,7 +11,7 @@ navactive: index
 Note. Only components that are part of the global platform should be added to this page of components.
 
 <div class="g g--gutter g--stack--mid">
-    <div class="g-col g-span6">
+    <div class="g-col g-span4">
 {{#markdown}}
 
 <h3 class="sg-sectionHeading">Objects</h3>
@@ -22,7 +22,7 @@ Note. Only components that are part of the global platform should be added to th
 
 {{/markdown}}
     </div>
-    <div class="g-col g-span6">
+    <div class="g-col g-span4">
 {{#markdown}}
 
 <h3 class="sg-sectionHeading">Components</h3>
@@ -30,11 +30,21 @@ Note. Only components that are part of the global platform should be added to th
 - [Headers](headers/)
 - [Footers](footers/)
 - [Breadcrumbs](breadcrumbs)
-- [Cards](cards)
-- [Badges](Badges)
 - [Star Ratings](star-ratings)
 - [Listings](listings)
 - [Media Element](mediaElement)
+- [Icons](ui-icons)
+
+{{/markdown}}
+    </div>
+    <div class="g-col g-span4">
+{{#markdown}}
+
+<h3 class="sg-sectionHeading">Optional Components</h3>
+
+- [Cards](cards)
+- [Badges](Badges)
+- [Page Banners](page-banner)
 
 {{/markdown}}
     </div>

--- a/docs/src/templates/pages/styleguide/ui-components/index.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/index.hbs
@@ -12,19 +12,16 @@ Note. Only components that are part of the global platform should be added to th
 
 <div class="g g--gutter g--stack--mid">
     <div class="g-col g-span4">
-{{#markdown}}
-
+        {{#markdown}}
 <h3 class="sg-sectionHeading">Objects</h3>
 
 - [Buttons](buttons)
 - [Checkboxes](forms/checkboxes)
 - [Radio Buttons](forms/radio-buttons)
-
-{{/markdown}}
+        {{/markdown}}
     </div>
     <div class="g-col g-span4">
-{{#markdown}}
-
+        {{#markdown}}
 <h3 class="sg-sectionHeading">Components</h3>
 
 - [Headers](headers/)
@@ -34,18 +31,15 @@ Note. Only components that are part of the global platform should be added to th
 - [Listings](listings)
 - [Media Element](mediaElement)
 - [Icons](ui-icons)
-
-{{/markdown}}
+        {{/markdown}}
     </div>
     <div class="g-col g-span4">
-{{#markdown}}
-
+        {{#markdown}}
 <h3 class="sg-sectionHeading">Optional Components</h3>
 
 - [Cards](cards)
 - [Badges](Badges)
 - [Page Banners](page-banner)
-
-{{/markdown}}
+        {{/markdown}}
     </div>
 </div>

--- a/docs/src/templates/pages/styleguide/ui-components/mediaElement.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/mediaElement.hbs
@@ -7,9 +7,13 @@ navgroup: styleguide
 navsub: ui-components
 navactive: mediaElement
 ---
+
 <p>A common pattern that sees an image followed by a block of information.</p>
+
+
 <h2 class="sg-sectionHeading">Default Media Element</h2>
 <p>Image on the left, block of information on the right.</p>
+
 {{#>demo-block }}
 <div class="c-mediaElement">
     <div class="c-mediaElement-img">
@@ -21,8 +25,11 @@ navactive: mediaElement
     </div>
 </div>
 {{/demo-block }}
+
+
 <h2 class="sg-sectionHeading">Stacked Media Element</h2>
 <p>Default media element on wide viewports, on narrow it reverts to the image on the top, with the block of information below it.</p>
+
 {{#>demo-block }}
 <div class="c-mediaElement c-mediaElement--stack">
     <div class="c-mediaElement-img">
@@ -34,8 +41,11 @@ navactive: mediaElement
     </div>
 </div>
 {{/demo-block }}
+
+
 <h2 class="sg-sectionHeading">Fully Stacked Media Element</h2>
 <p>Stacked on all view widths – image on the top, the block of information below it.</p>
+
 {{#>demo-block }}
 <div class="c-mediaElement c-mediaElement--fullstack">
     <div class="c-mediaElement-img">
@@ -47,8 +57,11 @@ navactive: mediaElement
     </div>
 </div>
 {{/demo-block }}
+
+
 <h2 class="sg-sectionHeading">Modifiers</h2>
 <p>Image outlined</p>
+
 {{#>demo-block }}
 <div class="c-mediaElement">
     <div class="c-mediaElement-img c-mediaElement-img--outlined">
@@ -60,7 +73,10 @@ navactive: mediaElement
     </div>
 </div>
 {{/demo-block }}
+
+
 <p>Text large</p>
+
 {{#>demo-block }}
 <div class="c-mediaElement">
     <div class="c-mediaElement-img">

--- a/docs/src/templates/pages/styleguide/ui-components/page-banner.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/page-banner.hbs
@@ -1,0 +1,18 @@
+---
+title: Page Banner
+section-title: UI Components
+docs: true
+
+navgroup: styleguide
+navsub: ui-components
+navactive: pagebanner
+---
+
+<p>Page Banners stretch to the full width of their container, and contain banner images which typically use a <code>picture</code> element. They also display a white version of the Just Eat rays at the bottom.</p>
+
+<p><em>The <code>pageBanner</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include pageBanner();</code> into your SCSS dependencies file.</em></p>
+
+<h2 class="sg-sectionHeading">Page Banner</h2>
+{{#>demo-block demoVisualCssClass="demo-visual--spacingBottom" }}
+{{> je-pageBanner }}
+{{/demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
@@ -8,10 +8,6 @@ navsub: ui-components
 navactive: ui-icons
 ---
 
-<p>Badges can be used to display small pieces of information.</p>
-
-<p><em>The <code>badge</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include badge();</code> into your SCSS dependencies file.</em></p>
-
 <h2 class="sg-sectionHeading">General Icons</h2>
 
 <h3 class="sg-sectionHeading">Alert – <code>.c-icon--alert</code></h3>
@@ -138,7 +134,7 @@ navactive: ui-icons
 {{inlineSVG "@justeat/f-icons/src/img/icons/cards/amex--safekey.svg" class="c-icon c-icon--amex--safekey"}}
 {{/demo-block }}
 
-<h3 class="sg-sectionHeading">DK – <code>.c-icon--dk</code></h3>
+<h3 class="sg-sectionHeading">Dankort – <code>.c-icon--dk</code></h3>
 {{#>demo-block }}
 {{inlineSVG "@justeat/f-icons/src/img/icons/cards/dk.svg" class="c-icon c-icon--dk"}}
 {{/demo-block }}
@@ -219,7 +215,7 @@ navactive: ui-icons
 {{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.fr.svg" class="c-icon c-icon--flag"}}
 {{/demo-block }}
 
-<h3 class="sg-sectionHeading">Great Britain – <code>.c-icon--flag</code></h3>
+<h3 class="sg-sectionHeading">United Kingdom – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
 {{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.gb.svg" class="c-icon c-icon--flag"}}
 {{/demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
@@ -1,0 +1,294 @@
+---
+title: Icons
+section-title: UI Components
+docs: true
+
+navgroup: styleguide
+navsub: ui-components
+navactive: ui-icons
+---
+
+<p>Badges can be used to display small pieces of information.</p>
+
+<p><em>The <code>badge</code> component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding <code>@include badge();</code> into your SCSS dependencies file.</em></p>
+
+<h2 class="sg-sectionHeading">General Icons</h2>
+
+<h3 class="sg-sectionHeading">Alert – <code>.c-icon--alert</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/alert.svg" class="c-icon c-icon--alert"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Basket – <code>.c-icon--basket</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/basket.svg" class="c-icon c-icon--basket"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Collection – <code>.c-icon--collection</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/collection.svg" class="c-icon c-icon--collection"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Delivery – <code>.c-icon--delivery</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/delivery.svg" class="c-icon c-icon--delivery"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Delivery Small – <code>.c-icon--delivery--small</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/delivery.svg" class="c-icon c-icon--delivery c-icon--delivery--small"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Info – <code>.c-icon--info</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/info.svg" class="c-icon c-icon--info"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Nut Allergy – <code>.c-icon--nutAllergy</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/nutAllergy.svg" class="c-icon c-icon--nutAllergy"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Offer – <code>.c-icon--offer</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-icon c-icon--offer"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Offer Small – <code>.c-icon--offer--small</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-icon c-icon--offer c-icon--offer--small"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Spicy – <code>.c-icon--spicy</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/spicy.svg" class="c-icon c-icon--spicy"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Tick – <code>.c-icon--tick</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/tick.svg" class="c-icon c-icon--tick"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Vegetarian – <code>.c-icon--vegetarian</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/general/vegetarian.svg" class="c-icon c-icon--vegetarian"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Tool Icons</h2>
+
+<h3 class="sg-sectionHeading">Eyeglass – <code>.c-icon--eyeglass</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/tools/eyeglass.svg" class="c-icon c-icon--eyeglass"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Horizontal Sliders – <code>.c-icon--slidersHorizontal</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/tools/slidersHorizontal.svg" class="c-icon c-icon--slidersHorizontal"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Sort Amount – <code>.c-icon--sortAmount</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/tools/sortAmount.svg" class="c-icon c-icon--sortAmount"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Map Pin – <code>.c-icon--mapPin</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/tools/mapPin.svg" class="c-icon c-icon--mapPin"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Arrow Icons</h2>
+
+<h3 class="sg-sectionHeading">Chevron – <code>.c-icon--chevron</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Chevron Small – <code>.c-icon--chevron--small</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--small"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Chevron Up – <code>.c-icon--chevron--up</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--up"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Chevron Right – <code>.c-icon--chevron--right</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--right"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Chevron Light – <code>.c-icon--chevron--light</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--light"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Card Icons</h2>
+
+<h3 class="sg-sectionHeading">Amex – <code>.c-icon--amex</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/amex.svg" class="c-icon c-icon--amex"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Amex Safekey – <code>.c-icon--amex--safekey</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/amex--safekey.svg" class="c-icon c-icon--amex--safekey"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">DK – <code>.c-icon--dk</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/dk.svg" class="c-icon c-icon--dk"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Interac – <code>.c-icon--interac</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/interac.svg" class="c-icon c-icon--interac"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">MasterCard – <code>.c-icon--mastercard</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/mastercard.svg" class="c-icon c-icon--mastercard"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">MasterCard Secure Code – <code>.c-icon--mastercard--securecode</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/mastercard--securecode.svg" class="c-icon c-icon--mastercard--securecode"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">PayPal – <code>.c-icon--paypal</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/paypal.svg" class="c-icon c-icon--paypal"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Visa – <code>.c-icon--visa</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/visa.svg" class="c-icon c-icon--visa"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Visa Verified – <code>.c-icon--visa--verified</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/visa--verified.svg" class="c-icon c-icon--visa--verified"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Maestro – <code>.c-icon--maestro</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/cards/maestro.svg" class="c-icon c-icon--maestro"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Certificate Icons</h2>
+
+<h3 class="sg-sectionHeading">Confianza – <code>.c-icon--confianza</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/certificates/confianza.svg" class="c-icon c-icon--confianza"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Flag Icons</h2>
+
+<h3 class="sg-sectionHeading">Australia – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.au.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Brazil – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.br.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Canada – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ca.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Denmark – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.dk.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Spain – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.es.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">France – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.fr.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Great Britain – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.gb.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Ireland – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ie.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Italy – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.it.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Norway – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.no.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">New Zealand – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.nz.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Switzerland – <code>.c-icon--flag</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ch.svg" class="c-icon c-icon--flag"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Operator Icons</h2>
+
+<h3 class="sg-sectionHeading">Cross – <code>.c-icon--cross</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/operators/cross.svg" class="c-icon c-icon--cross"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Minus – <code>.c-icon--minus</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/operators/minus.svg" class="c-icon c-icon--minus"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Plus – <code>.c-icon--plus</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/operators/plus.svg" class="c-icon c-icon--plus"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Plus – <code>.c-icon--plus--thin</code></h3>
+{{#>demo-block }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/operators/plus--thin.svg" class="c-icon c-icon--plus--thin"}}
+{{/demo-block }}
+
+
+<h2 class="sg-sectionHeading">Rating Icons</h2>
+
+<h3 class="sg-sectionHeading">Star – <code>.c-icon--star</code></h3>
+{{#>demo-block demoVisualCssClass="l-inlined" }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star"}}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star"}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Star Medium – <code>.c-icon--star</code></h3>
+{{#>demo-block demoVisualCssClass="l-inlined" }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star--medium "}}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star--medium "}}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Star Large – <code>.c-icon--star</code></h3>
+{{#>demo-block demoVisualCssClass="l-inlined" }}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star--large"}}
+{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star--large"}}
+{{/demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-templates/menu/menu-delivery.hbs
+++ b/docs/src/templates/pages/styleguide/ui-templates/menu/menu-delivery.hbs
@@ -7,13 +7,8 @@ styleguide: true
 bodyClass: o-body--bgWhite--belowMid
 ---
 
-<div class="c-pageBanner c-pageBanner--negativeBottom--aboveMid">
-    <picture>
-        <source class="c-pageBanner-img" media="(min-width: 860px)" srcset="{{baseUrl}}/assets/img/examples/kebabs--wide.jpg" data-ft="restaurant-level-image--wide">
-        <source class="c-pageBanner-img" media="(min-width: 600px)" srcset="{{baseUrl}}/assets/img/examples/kebabs--mid.jpg" data-ft="restaurant-level-image--mid">
-        <img class="c-pageBanner-img" srcset="{{baseUrl}}/assets/img/examples/kebabs--narrow.jpg" alt="" data-ft="restaurant-level-image--narrow" >
-    </picture>
-</div>
+{{> je-pageBanner }}
+
 <div class="l-container">
     <div class="g g--stack g--gutter l-content">
         <div class="g-col g-span3--mid g-span2--wide">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"
@@ -22,10 +22,10 @@
     "@justeat/f-dom": "^0.4.0",
     "@justeat/f-footer": "^0.35.2",
     "@justeat/f-header": "0.34.0",
-    "@justeat/f-icons": "1.5.0",
+    "@justeat/f-icons": "1.6.0",
     "@justeat/f-toggle": "1.1.0",
     "@justeat/f-validate": "^1.1.0",
-    "@justeat/fozzie": "0.63.0",
+    "@justeat/fozzie": "0.65.0",
     "kickoff-grid.css": "^1.1.0",
     "lite-ready": "^1.0.4",
     "qwery": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,9 +86,9 @@
     include-media "^1.4.9"
     lite-ready "^1.0.4"
 
-"@justeat/f-icons@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.5.0.tgz#5f70ce20743975b2f271c1a94aeae66a8b997ab5"
+"@justeat/f-icons@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-icons/-/f-icons-1.6.0.tgz#d6df78400c4781105d5b50c09c733cff4fa9ebaa"
   dependencies:
     "@kickoff/utils.scss" "2.1.1"
     include-media "^1.4.9"
@@ -119,9 +119,9 @@
   version "1.4.0"
   resolved "https://registry.npmjs.org/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-1.4.0.tgz#70dffb05eafc834f348957a6ff06588ebdf877c9"
 
-"@justeat/fozzie@0.63.0":
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-0.63.0.tgz#9bd1b3a55a4f42a176ae724b7ec4ab964c1a6a1d"
+"@justeat/fozzie@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-0.65.0.tgz#8c02bf828bdb95121c6206de906b19888b3defb5"
   dependencies:
     "@justeat/f-dom" "^0.3.0"
     "@justeat/fozzie-colour-palette" "^1.1.0"


### PR DESCRIPTION
### Added
- Page Banner documentation.
- Icon documentation.
- Ability to specify a visual docs demo CSS class.
- Docs visual spacing bottom CSS class.

### Changed
- Reordered component subnav items.
- Tweaks to the sentence order of the cards and badges documentation.
- Component index split across three columns.
- Menu template using new `je-pagebanner` partial.
- Updated Fozzie dependency.