### PR TITLE
v1.21.0 - addition of documentation for c-badge --noPad modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.21.0
+------------------------------
+*September 5, 2018*
+
+### Added
+- Added new `c-badge` modifier - `c-badge--noPad`.
+- Added `c-badge--noPad` examples.
+
 v1.20.0
 ------------------------------
 *September 3, 2018*

--- a/docs/src/templates/pages/styleguide/ui-components/badges.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/badges.hbs
@@ -38,6 +38,11 @@ layout: components
 <span class="c-badge c-badge--light">Light <span>•</span> badge</span>
 {{/demo-block }}
 
+<h2 class="sg-sectionHeading">Light Badge with no padding– <code>.c-badge c-badge--light c-badge--noPad</code></h2>
+{{#>demo-block }}
+<span class="c-badge c-badge--light c-badge--noPad">Light <span>•</span> badge</span>
+{{/demo-block }}
+
 <h2 class="sg-sectionHeading">Info Badge – <code>.c-badge c-badge--info</code></h2>
 {{#>demo-block }}
 <span class="c-badge c-badge--info">Info</span>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"
@@ -25,7 +25,7 @@
     "@justeat/f-icons": "1.8.0",
     "@justeat/f-toggle": "1.1.0",
     "@justeat/f-validate": "1.1.0",
-    "@justeat/fozzie": "0.70.0",
+    "@justeat/fozzie": "0.74.0",
     "kickoff-grid.css": "1.1.0",
     "lite-ready": "1.0.4",
     "qwery": "4.0.0",


### PR DESCRIPTION
- addition of documentation for c-badge --noPad modifier
<img width="1031" alt="screen shot 2018-09-05 at 10 36 38" src="https://user-images.githubusercontent.com/5295718/45085115-cd258900-b0f7-11e8-83f9-d28742ae2f45.png">
