### PR TITLE
v1.22.0 — Added menu documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
+  - "10"
 
 cache: yarn
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.22.0
+------------------------------
+*September 5, 2018*
+
+### Added
+- Menu documentation.
+- Code is linted when the `prepare` hook is fired.
+
+### Changed
+- Updated Travis config to run using Node v8 & v10.
+
+
 v1.21.0
 ------------------------------
 *September 5, 2018*
@@ -11,6 +23,7 @@ v1.21.0
 ### Added
 - Added new `c-badge` modifier - `c-badge--noPad`.
 - Added `c-badge--noPad` examples.
+
 
 v1.20.0
 ------------------------------

--- a/assets/src/scss/_dependencies.scss
+++ b/assets/src/scss/_dependencies.scss
@@ -32,6 +32,7 @@
 @include card();
 @include badge();
 @include pageBanner();
+@include menu();
 
 
 /**

--- a/docs/src/templates/includes/components/core/je-menu.hbs
+++ b/docs/src/templates/includes/components/core/je-menu.hbs
@@ -1,0 +1,36 @@
+<nav aria-labelledby="{{ariaLabelledBy}}">
+    <h2 class="is-visuallyHidden" id="{{ariaLabelledBy}}">Categories</h2>
+
+    <ul class="c-menu {{cssClass}}">
+        <li class="c-menu-item c-menu-item--active {{#if showPopular}}has-icon{{/if}}">
+            <a href="" class="c-menu-link">Popular</a>
+            {{#if showPopular}}
+                {{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-menu-icon c-icon c-icon--offer c-icon--offer--small c-icon--orange"}}
+            {{/if}}
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 1</a>
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 2</a>
+        </li>
+        <li class="c-menu-item {{#if showPopular}}has-icon{{/if}}">
+            <a href="" class="c-menu-link">Category 3 has a really really long title</a>
+            {{#if showPopular}}
+                {{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-menu-icon c-icon c-icon--offer c-icon--offer--small c-icon--orange"}}
+            {{/if}}
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 4</a>
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 5</a>
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 6</a>
+        </li>
+        <li class="c-menu-item">
+            <a href="" class="c-menu-link">Category 7</a>
+        </li>
+    </ul>
+</nav>

--- a/docs/src/templates/includes/documentation-components/subnavs/subnav--sidebar.hbs
+++ b/docs/src/templates/includes/documentation-components/subnavs/subnav--sidebar.hbs
@@ -31,6 +31,7 @@
     <!-- subnav for Styleguide > Optional Components -->
     <li><a href="{{ baseUrl }}/styleguide/ui-components/cards" class="{{#is navactive 'cards'}} is-active{{/is}}">Cards</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/badges" class="{{#is navactive 'badges'}} is-active{{/is}}">Badges</a></li>
+    <li><a href="{{ baseUrl }}/styleguide/ui-components/menu" class="{{#is navactive 'menu'}} is-active{{/is}}">Menu</a></li>
     <li><a href="{{ baseUrl }}/styleguide/ui-components/page-banner" class="{{#is navactive 'pagebanner'}} is-active{{/is}}">Page Banner</a></li>
 
     <!-- subnav for Styleguide > To Do -->

--- a/docs/src/templates/pages/styleguide/ui-components/index.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/index.hbs
@@ -39,6 +39,7 @@ Note. Only components that are part of the global platform should be added to th
 
 - [Cards](cards)
 - [Badges](Badges)
+- [Menu](menu)
 - [Page Banners](page-banner)
         {{/markdown}}
     </div>

--- a/docs/src/templates/pages/styleguide/ui-components/menu.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/menu.hbs
@@ -1,0 +1,54 @@
+---
+title: Menu
+section-title: UI Components
+docs: true
+
+navgroup: styleguide
+navsub: ui-components
+navactive: menu
+layout: components
+---
+
+{{#markdown}}
+Use the menu component to create styled lists of links used for navigation.
+
+When the container is shorter than the text of a menu link the text will be truncated.
+
+> _The `menu` component is an optional mixin within Fozzie — if you'd like to use it in your project you can include it by adding `@include menu();` into your SCSS dependencies file._
+
+## Accessibility
+
+Be sure to wrap your menu components in a `<nav>` element to aid assistive technologies in identifying the menu. If you have more than one menu component on a page add an `aria-labelledby` attribute and target an element (via its ID) in order to describe the intent of the menu.
+{{/markdown}}
+
+<h2 class="sg-sectionHeading">Menu</h2>
+{{#>demo-block }}
+<div class="g">
+    <div class="g-col g-span3">
+        {{> je-menu ariaLabelledBy="example-1" }}
+    </div>
+</div>
+{{/demo-block }}
+
+<h2 class="sg-sectionHeading">Condensed Menu</h2>
+{{#>demo-block }}
+<div class="g">
+    <div class="g-col g-span3">
+        {{> je-menu cssClass="c-menu--condensed" ariaLabelledBy="example-2"}}
+    </div>
+</div>
+{{/demo-block }}
+
+<h2 class="sg-sectionHeading">Menu with icons</h2>
+{{#>demo-block }}
+<div class="g">
+    <div class="g-col g-span3">
+        {{> je-menu ariaLabelledBy="example-3" showPopular=true }}
+    </div>
+</div>
+{{/demo-block }}
+
+<h2 class="sg-sectionHeading">Horizontal Menu</h2>
+{{#>demo-block }}
+{{> je-menu cssClass="c-menu--horizontal" ariaLabelledBy="example-4" }}
+{{/demo-block }}

--- a/docs/src/templates/pages/styleguide/ui-templates/menu/menu-delivery.hbs
+++ b/docs/src/templates/pages/styleguide/ui-templates/menu/menu-delivery.hbs
@@ -11,7 +11,10 @@ bodyClass: o-body--bgWhite--belowMid
 
 <div class="l-container">
     <div class="g g--stack g--gutter l-content">
-        <div class="g-col g-span2--mid">
+        <div class="g-col g-span2--mid u-showAboveMid">
+            {{> je-menu
+                cssClass="c-menu--spacingTop--aboveMid"
+                ariaLabelledBy="categories-title" }}
         </div>
         <div class="g-col g-span6--mid">
             {{> je-menu-header
@@ -20,7 +23,7 @@ bodyClass: o-body--bgWhite--belowMid
                 isBtaWinner=true
                 star-rating=30
                 star-rating-display=3
-                star-rating-count=566}}
+                star-rating-count=566 }}
         </div>
         <div class="g-col g-span4--mid">
         </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"
@@ -25,16 +25,16 @@
     "@justeat/f-icons": "1.8.0",
     "@justeat/f-toggle": "1.1.0",
     "@justeat/f-validate": "1.1.0",
-    "@justeat/fozzie": "0.74.0",
+    "@justeat/fozzie": "0.75.0",
     "kickoff-grid.css": "1.1.0",
     "lite-ready": "1.0.4",
     "qwery": "4.0.0",
     "svg4everybody": "2.1.9"
   },
   "devDependencies": {
-    "@justeat/gulp-build-fozzie": "7.25.0",
+    "@justeat/gulp-build-fozzie": "7.26.0",
     "babel-preset-env": "1.7.0",
-    "danger": "3.8.8",
+    "danger": "3.8.9",
     "eslint-plugin-import": "2.14.0",
     "gulp": "3.9.1"
   },
@@ -46,7 +46,11 @@
     "prestart": "yarn",
     "start": "gulp docs",
     "predeploy": "yarn --ignore-optional",
-    "deploy": "gulp docs:deploy"
+    "deploy": "gulp docs:deploy",
+    "prepare": "yarn lint",
+    "lint": "yarn run lint:css && yarn run lint:js",
+    "lint:css": "gulp scss:lint --prod",
+    "lint:js": "gulp scripts:lint --prod"
   },
   "scripts-info": {
     "start": "Start up the Global Component Library locally",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.52"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.52.tgz#192483bfa0d1e467c101571c21029ccb74af2801"
@@ -15,6 +21,14 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
 
 "@gimenete/type-writer@^0.1.3":
   version "0.1.3"
@@ -40,18 +54,18 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@justeat/eslint-config-fozzie@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-2.1.0.tgz#b647699ce1c8e6063737c45114ebe79085a65a09"
+"@justeat/eslint-config-fozzie@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@justeat/eslint-config-fozzie/-/eslint-config-fozzie-2.2.0.tgz#30723339f6f6621a9b781dae0e44658a12851a98"
   dependencies:
-    eslint-config-airbnb-base "^13.0.0"
+    eslint-config-airbnb-base "^13.1.0"
 
-"@justeat/f-copy-assets@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/@justeat/f-copy-assets/-/f-copy-assets-0.6.0.tgz#6908c50dd710fb344256fbece2c0cf7b303b236c"
+"@justeat/f-copy-assets@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-copy-assets/-/f-copy-assets-1.1.0.tgz#7fe46e30d055a0c24578bfa2c251e689f158b8b9"
   dependencies:
-    glob "^7.1.2"
-    mkdirp "^0.5.1"
+    glob "7.1.2"
+    mkdirp "0.5.1"
 
 "@justeat/f-dom@0.4.0", "@justeat/f-dom@^0.4.0":
   version "0.4.0"
@@ -119,7 +133,7 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-1.1.0.tgz#05a49eaa55000fa1f0b916603d341eef8bfbf439"
 
-"@justeat/fozzie-colour-palette@^1.1.0", "@justeat/fozzie-colour-palette@^1.2.0":
+"@justeat/fozzie-colour-palette@1.4.0", "@justeat/fozzie-colour-palette@^1.1.0", "@justeat/fozzie-colour-palette@^1.2.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-1.4.0.tgz#70dffb05eafc834f348957a6ff06588ebdf877c9"
 
@@ -134,34 +148,34 @@
     kickoff-grid.css "^1.1.2"
     normalize-scss "^7.0.1"
 
-"@justeat/fozzie@0.70.0":
-  version "0.70.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-0.70.0.tgz#f9541aab6284eca1fd0fd735aa049570b63e2635"
+"@justeat/fozzie@0.75.0":
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-0.75.0.tgz#36eaf11b8d9957cac2039d402dd2eca1dc69ffa4"
   dependencies:
-    "@justeat/f-dom" "^0.3.0"
-    "@justeat/fozzie-colour-palette" "^1.1.0"
-    "@kickoff/utils.scss" "^2.1.1"
-    include-media "^1.4.9"
-    kickoff-grid.css "^1.1.2"
-    normalize-scss "^7.0.1"
+    "@justeat/f-dom" "0.4.0"
+    "@justeat/fozzie-colour-palette" "1.4.0"
+    "@kickoff/utils.scss" "2.1.1"
+    include-media "1.4.9"
+    kickoff-grid.css "1.1.2"
+    normalize-scss "7.0.1"
 
-"@justeat/gulp-build-fozzie@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-7.25.0.tgz#f612abaf82af9e2b8411ffa9715ac47c8df33c7a"
+"@justeat/gulp-build-fozzie@7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@justeat/gulp-build-fozzie/-/gulp-build-fozzie-7.26.0.tgz#4947add9d9f4d4ba2f175c28e5ca2e983489d921"
   dependencies:
-    "@justeat/eslint-config-fozzie" "2.1.0"
-    "@justeat/f-copy-assets" "^0.6.0"
+    "@justeat/eslint-config-fozzie" "2.2.0"
+    "@justeat/f-copy-assets" "^1.1.0"
     "@justeat/f-templates-loader" "0.1.0"
     "@justeat/gulp-gh-pages" "^1.0.3"
     "@justeat/stylelint-config-fozzie" "^2.0.1"
     assemble "^0.24.3"
     autoprefixer "^9.1.0"
     babelify "^8.0.0"
-    browser-sync "^2.24.6"
+    browser-sync "^2.24.7"
     browserify "^16.1.1"
-    cssnano "^4.0.5"
+    cssnano "^4.1.0"
     del "^3.0.0"
-    eslint "^5.2.0"
+    eslint "^5.5.0"
     eslint-plugin-import "^2.9.0"
     event-stream "^3.3.4"
     exorcist "^1.0.1"
@@ -179,7 +193,7 @@
     gulp-imagemin "^4.1.0"
     gulp-newer "^1.4.0"
     gulp-plumber "^1.2.0"
-    gulp-postcss "^7.0.1"
+    gulp-postcss "^8.0.0"
     gulp-rename "^1.4.0"
     gulp-rev "^8.1.1"
     gulp-sass "^4.0.1"
@@ -187,8 +201,9 @@
     gulp-size "^3.0.0"
     gulp-sourcemaps "^2.6.4"
     gulp-strip-debug "^3.0.0"
+    gulp-stylelint "^7.0.0"
     gulp-svgmin "^1.2.4"
-    gulp-svgstore "^6.1.1"
+    gulp-svgstore "^7.0.0"
     gulp-tap "^1.0.1"
     gulp-uglify-es "^1.0.4"
     gulp-util "^3.0.8"
@@ -200,8 +215,7 @@
     lodash.union "^4.6.0"
     merge-stream "^1.0.1"
     postcss-assets "^5.0.0"
-    postcss-reporter "^5.0.0"
-    postcss-scss "^2.0.0"
+    postcss-reporter "^6.0.0"
     require-dir "^1.0.0"
     run-sequence "^2.2.1"
     stylelint "^9.4.0"
@@ -357,6 +371,15 @@ ajv@^6.0.1, ajv@^6.5.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
+
+ajv@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -835,6 +858,10 @@ arrayify-compact@^0.2.0:
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -2127,9 +2154,9 @@ browser-sync-ui@v1.0.1:
     socket.io-client "2.0.4"
     stream-throttle "^0.1.3"
 
-browser-sync@^2.24.6:
-  version "2.24.6"
-  resolved "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.6.tgz#dacb9b2d8f985cfc4e55b9ca881f5a5970617ee8"
+browser-sync@^2.24.7:
+  version "2.24.7"
+  resolved "https://registry.yarnpkg.com/browser-sync/-/browser-sync-2.24.7.tgz#0f93bcaabfb84a35a5c98e07682c9e45c6251a93"
   dependencies:
     browser-sync-ui v1.0.1
     bs-recipes "1.3.4"
@@ -2137,7 +2164,7 @@ browser-sync@^2.24.6:
     connect "3.6.6"
     connect-history-api-fallback "^1.5.0"
     dev-ip "^1.0.1"
-    easy-extender "2.3.2"
+    easy-extender "^2.3.4"
     eazy-logger "3.0.2"
     etag "^1.8.1"
     fresh "^0.5.2"
@@ -2146,7 +2173,7 @@ browser-sync@^2.24.6:
     immutable "3.8.2"
     localtunnel "1.9.0"
     micromatch "2.3.11"
-    opn "4.0.2"
+    opn "5.3.0"
     portscanner "2.1.1"
     qs "6.2.3"
     raw-body "^2.3.2"
@@ -2585,6 +2612,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+
 cheerio@0.*:
   version "0.22.0"
   resolved "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
@@ -3018,17 +3049,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
   dependencies:
     is-directory "^0.3.1"
-    js-yaml "^3.4.3"
-    minimist "^1.2.0"
-    object-assign "^4.1.0"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    require-from-string "^1.1.0"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
 
 cosmiconfig@^5.0.0:
   version "5.0.5"
@@ -3257,9 +3285,9 @@ cssnano-util-same-parent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.0.tgz#d2a3de1039aa98bc4ec25001fa050330c2a16dac"
 
-cssnano@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/cssnano/-/cssnano-4.0.5.tgz#8789b5fdbe7be05d8a0f7e45c4c789ebe712f5aa"
+cssnano@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.0.tgz#682c37b84b9b7df616450a5a8dc9269b9bd10734"
   dependencies:
     cosmiconfig "^5.0.0"
     cssnano-preset-default "^4.0.0"
@@ -3307,9 +3335,9 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-danger@3.8.8:
-  version "3.8.8"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-3.8.8.tgz#4bd7715c38a5f82dad6ef6b069cc23065a6bcd27"
+danger@3.8.9:
+  version "3.8.9"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-3.8.9.tgz#bca0f3e6eb24f5c6e3b4740f49921b9308933f50"
   dependencies:
     "@octokit/rest" "^15.9.5"
     babel-polyfill "^6.23.0"
@@ -3501,6 +3529,10 @@ deep-bind@^0.3.0:
   resolved "https://registry.npmjs.org/deep-bind/-/deep-bind-0.3.0.tgz#95c31dd84a1cd1b381119a2c42edb90db485bc33"
   dependencies:
     mixin-deep "^1.1.3"
+
+deep-extend@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -3831,11 +3863,11 @@ each-async@^1.0.0, each-async@^1.1.1:
     onetime "^1.0.0"
     set-immediate-shim "^1.0.0"
 
-easy-extender@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz#3d3248febe2b159607316d8f9cf491c16648221d"
+easy-extender@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/easy-extender/-/easy-extender-2.3.4.tgz#298789b64f9aaba62169c77a2b3b64b4c9589b8f"
   dependencies:
-    lodash "^3.10.1"
+    lodash "^4.17.10"
 
 eazy-logger@3.0.2:
   version "3.0.2"
@@ -4118,9 +4150,9 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.0.0.tgz#2ee6279c4891128e49d6445b24aa13c2d1a21450"
+eslint-config-airbnb-base@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz#b5a1b480b80dfad16433d6c4ad84e6605052c05c"
   dependencies:
     eslint-restricted-globals "^0.1.1"
     object.assign "^4.1.0"
@@ -4189,7 +4221,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.0.1, eslint@^5.2.0:
+eslint@^5.0.1:
   version "5.2.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-5.2.0.tgz#3901ae249195d473e633c4acbc370068b1c964dc"
   dependencies:
@@ -4228,6 +4260,49 @@ eslint@^5.0.1, eslint@^5.2.0:
     require-uncached "^1.0.3"
     semver "^5.5.0"
     string.prototype.matchall "^2.0.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
+
+eslint@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.5.0.tgz#8557fcceab5141a8197da9ffd9904f89f64425c6"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    imurmurhash "^0.1.4"
+    inquirer "^6.1.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
     table "^4.0.3"
@@ -4529,6 +4604,14 @@ external-editor@^2.0.1, external-editor@^2.1.0:
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -5179,6 +5262,17 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^4.3.1:
   version "4.5.3"
   resolved "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
@@ -5205,17 +5299,6 @@ glob@^6.0.4:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -5529,14 +5612,14 @@ gulp-plumber@^1.2.0:
     plugin-error "^0.1.2"
     through2 "^2.0.3"
 
-gulp-postcss@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz#3f1c36db1197140c399c252ddff339129638e395"
+gulp-postcss@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-postcss/-/gulp-postcss-8.0.0.tgz#8d3772cd4d27bca55ec8cb4c8e576e3bde4dc550"
   dependencies:
     fancy-log "^1.3.2"
-    plugin-error "^0.1.2"
-    postcss "^6.0.0"
-    postcss-load-config "^1.2.0"
+    plugin-error "^1.0.1"
+    postcss "^7.0.2"
+    postcss-load-config "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
 gulp-rename@^1.2.0:
@@ -5626,6 +5709,20 @@ gulp-strip-debug@^3.0.0:
     strip-debug "^3.0.0"
     through2 "^2.0.0"
 
+gulp-stylelint@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-stylelint/-/gulp-stylelint-7.0.0.tgz#4249dc36a983e6a2c28a449f73d9a369bb14b458"
+  dependencies:
+    chalk "^2.3.0"
+    deep-extend "^0.5.0"
+    fancy-log "^1.3.2"
+    mkdirp "^0.5.1"
+    plugin-error "^1.0.1"
+    promise "^8.0.1"
+    source-map "^0.5.6"
+    strip-ansi "^4.0.0"
+    through2 "^2.0.3"
+
 gulp-svgmin@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz#a4aa9e2615cf1105ef555aea86e86296cc20e273"
@@ -5633,9 +5730,9 @@ gulp-svgmin@^1.2.4:
     gulp-util "^3.0.4"
     svgo "^0.7.0"
 
-gulp-svgstore@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.1.tgz#7fa8af005c23bb0338f9f365a6010c86651f13d0"
+gulp-svgstore@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-svgstore/-/gulp-svgstore-7.0.0.tgz#87655e7c4c9c03b4c253a9884be76761d9054e32"
   dependencies:
     cheerio "0.*"
     fancy-log "^1.3.2"
@@ -6110,6 +6207,12 @@ iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
@@ -6127,6 +6230,10 @@ ignore@^3.3.5:
 ignore@^4.0.0, ignore@^4.0.2:
   version "4.0.3"
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.3.tgz#e2d58c9654d75b542529fa28d80ac95b29e4f467"
+
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 imagemin-gifsicle@^5.2.0:
   version "5.2.0"
@@ -6174,6 +6281,18 @@ imagemin@^5.3.1:
 immutable@3.8.2, immutable@^3.7.6:
   version "3.8.2"
   resolved "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
+import-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
+  dependencies:
+    import-from "^2.1.0"
+
+import-from@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
+  dependencies:
+    resolve-from "^3.0.0"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -6332,6 +6451,24 @@ inquirer@^5.2.0:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -6891,6 +7028,10 @@ is-word-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
 is-zip@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz#47b0a8ff4d38a76431ccfd99a8e15a4c86ba2325"
@@ -7298,11 +7439,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.12.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -7495,6 +7636,17 @@ kew@^0.7.0:
 kickoff-grid.css@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/kickoff-grid.css/-/kickoff-grid.css-1.1.0.tgz#506222709b282261aa9b4974b4f603cb3e57b7b8"
+  dependencies:
+    eyeglass "^1.1.2"
+    include-media "^1.4.8"
+    kickoff-utils.scss "^2.0.1"
+  optionalDependencies:
+    npm-scripts-info "^0.3.6"
+    release-it "2.4.0"
+
+kickoff-grid.css@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/kickoff-grid.css/-/kickoff-grid.css-1.1.2.tgz#f6a3602358e29a25bc1c61a770fbb621a0a3517e"
   dependencies:
     eyeglass "^1.1.2"
     include-media "^1.4.8"
@@ -8055,7 +8207,7 @@ lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^3.10.1, lodash@^3.7.0:
+lodash@^3.7.0:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -8872,7 +9024,7 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
-normalize-scss@^7.0.1:
+normalize-scss@7.0.1, normalize-scss@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/normalize-scss/-/normalize-scss-7.0.1.tgz#74485e82bb5d0526371136422a09fdb868ffc1a4"
 
@@ -9116,12 +9268,11 @@ openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
 
-opn@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz#7abc22e644dff63b0a96d5ab7f2790c0f01abc95"
+opn@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
   dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
+    is-wsl "^1.1.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -9694,28 +9845,12 @@ postcss-less@^2.0.0:
   dependencies:
     postcss "^5.2.16"
 
-postcss-load-config@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz#539e9afc9ddc8620121ebf9d8c3673e0ce50d28a"
+postcss-load-config@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.0.0.tgz#f1312ddbf5912cd747177083c5ef7a19d62ee484"
   dependencies:
-    cosmiconfig "^2.1.0"
-    object-assign "^4.1.0"
-    postcss-load-options "^1.2.0"
-    postcss-load-plugins "^2.3.0"
-
-postcss-load-options@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz#b098b1559ddac2df04bc0bb375f99a5cfe2b6d8c"
-  dependencies:
-    cosmiconfig "^2.1.0"
-    object-assign "^4.1.0"
-
-postcss-load-plugins@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz#745768116599aca2f009fad426b00175049d8d92"
-  dependencies:
-    cosmiconfig "^2.1.1"
-    object-assign "^4.1.0"
+    cosmiconfig "^4.0.0"
+    import-cwd "^2.0.0"
 
 postcss-markdown@^0.31.0:
   version "0.31.0"
@@ -9888,6 +10023,15 @@ postcss-reporter@^5.0.0:
     lodash "^4.17.4"
     log-symbols "^2.0.0"
     postcss "^6.0.8"
+
+postcss-reporter@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-6.0.0.tgz#44c873129d8c029a430b6d2186210d79c8de88b8"
+  dependencies:
+    chalk "^2.0.1"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    postcss "^7.0.2"
 
 postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
@@ -10070,6 +10214,12 @@ project-name@^0.2.4, project-name@^0.2.5, project-name@^0.2.6:
     find-pkg "^0.1.2"
     git-repo-name "^0.6.0"
     minimist "^1.2.0"
+
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
+  dependencies:
+    asap "~2.0.3"
 
 prompts@^0.1.9:
   version "0.1.13"
@@ -10446,6 +10596,10 @@ regexpp@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
 
+regexpp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -10703,13 +10857,9 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
-
-require-from-string@^2.0.2:
+require-from-string@^2.0.1, require-from-string@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
@@ -10947,6 +11097,12 @@ rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
+rxjs@^6.1.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.2.tgz#6a688b16c4e6e980e62ea805ec30648e1c60907f"
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -11033,6 +11189,10 @@ semver@5.3.0, semver@~5.3.0:
 semver@^4.0.3, semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 semver@~5.0.1:
   version "5.0.3"
@@ -12368,6 +12528,10 @@ trough@^1.0.0:
   dependencies:
     glob "^6.0.4"
 
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
 tty-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
@@ -12598,7 +12762,7 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^4.2.1:
+uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:


### PR DESCRIPTION
### Added
- Menu documentation.
- Code is linted when the `prepare` hook is fired.

### Changed
- Updated Travis config to run using Node v8 & v10.