### PR TITLE
v1.30.0 - `c-badge` doc updates and addition of stopFOIT preload module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.30.0
+------------------------------
+*September 26, 2018*
+
+### Added
+- Added Fozzie stopFOIT preload font classes to body.
+
+### Changed
+- Update `c-badge` docs with new a11y changes to divider.
+
+
 v1.29.0
 ------------------------------
 *September 14, 2018*

--- a/assets/src/js/index.js
+++ b/assets/src/js/index.js
@@ -1,10 +1,12 @@
 import '@justeat/f-footer';
 import { checkForUser } from '@justeat/f-header';
+import { stopFoit } from '@justeat/fozzie';
 import ready from 'lite-ready';
 import svg4everybody from 'svg4everybody';
 import setupValidation from './docs/formValidationSetup';
 
 ready(() => {
+    stopFoit();
     svg4everybody();
     setupValidation();
     checkForUser();

--- a/docs/src/templates/includes/components/core/menu/je-menu-header.hbs
+++ b/docs/src/templates/includes/components/core/menu/je-menu-header.hbs
@@ -13,7 +13,7 @@
                 <span class="u-spacingLeft u-showAboveWide">Restaurant info</span>
             </a>
             <p class="l-centered u-noSpacing">
-                <span class="c-badge c-badge--light c-badge--large">Kebab <span>•</span> Pizza</span>
+                <span class="c-badge c-badge--light c-badge--large">Kebab <span></span> Pizza</span>
             </p>
             <div class="l-centered u-spacingTop">
                 {{#if isNew}}

--- a/docs/src/templates/includes/documentation-components/html_start.hbs
+++ b/docs/src/templates/includes/documentation-components/html_start.hbs
@@ -18,6 +18,6 @@
 
         <link href='https://fonts.googleapis.com/css?family=Hind+Vadodara:300,500|Ubuntu:300,500' rel='stylesheet' type='text/css' />
 	</head>
-	<body class="{{#is layout 'site-frame'}}{{else}}body-docs{{/is}} {{ bodyClass }}">
+	<body class="{{#is layout 'site-frame'}}{{else}}body-docs{{/is}} {{ bodyClass }} is-fontsLoading--base is-fontsLoading--heading">
 
 

--- a/docs/src/templates/pages/styleguide/ui-components/badges.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/badges.hbs
@@ -35,17 +35,17 @@ layout: components
 
 <h2 class="sg-sectionHeading">Transparent Badge – <code>.c-badge c-badge--transparent</code></h2>
 {{#>demo-block }}
-<span class="c-badge c-badge--transparent">Transparent <span>•</span> badge</span>
+<span class="c-badge c-badge--transparent">Transparent <span></span> badge</span>
 {{/demo-block }}
 
 <h2 class="sg-sectionHeading">Light Badge – <code>.c-badge c-badge--light</code></h2>
 {{#>demo-block }}
-<span class="c-badge c-badge--light">Light <span>•</span> badge</span>
+<span class="c-badge c-badge--light">Light <span></span> badge</span>
 {{/demo-block }}
 
 <h2 class="sg-sectionHeading">Light Badge with no padding– <code>.c-badge c-badge--light c-badge--noPad</code></h2>
 {{#>demo-block }}
-<span class="c-badge c-badge--light c-badge--noPad">Light <span>•</span> badge</span>
+<span class="c-badge c-badge--light c-badge--noPad">Light <span></span> badge</span>
 {{/demo-block }}
 
 <h2 class="sg-sectionHeading">Info Badge – <code>.c-badge c-badge--info</code></h2>

--- a/docs/src/templates/pages/styleguide/ui-components/cards.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/cards.hbs
@@ -136,7 +136,7 @@ layout: components
     <img class="c-mediaElement-img" src="{{ baseUrl }}/assets/img/examples/restaurant-logo.gif" alt="Fozzie Kebab" />
     <div class="c-mediaElement-content">
         <h1>Fozzie Kebab</h1>
-        <p class="c-badge c-badge--light c-badge--large">Kebab <span>•</span> Pizza</p>
+        <p class="c-badge c-badge--light c-badge--large">Kebab <span></span> Pizza</p>
     </div>
 </div>
 {{/demo-block }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"
@@ -25,7 +25,7 @@
     "@justeat/f-icons": "1.10.0",
     "@justeat/f-toggle": "1.1.0",
     "@justeat/f-validate": "1.1.0",
-    "@justeat/fozzie": "0.92.0",
+    "@justeat/fozzie": "0.101.0",
     "bezier-easing": "2.1.0",
     "kickoff-grid.css": "1.2.0",
     "lite-ready": "1.0.4",


### PR DESCRIPTION
### Added
- Added Fozzie stopFOIT preload font classes to body.

### Changed
- Update `c-badge` docs with new a11y changes to divider.

**[no visual changes]**

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards
## Browsers Tested

- [x] Chrome
- [x] Safari
- [x] IE 11
- [x] Firefox
- [x] Mobile