### PR TITLE
v2.5.0 UI icons component update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.5.0
 ------------------------------
-*November 5, 2018*
+*November 6, 2018*
 
 ### Changed
 - UI-components icons to be called from svg sprite to improve "Show code" behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.5.0
+------------------------------
+*November 5, 2018*
+
+### Changed
+- UI-components icons to be called from svg sprite to improve "Show code" behaviour
+
+### Added
+- Social icons to UI icons component examples
+
 v2.4.0
 ------------------------------
 *November 2, 2018*

--- a/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
+++ b/docs/src/templates/pages/styleguide/ui-components/ui-icons.hbs
@@ -13,72 +13,72 @@ layout: components
 
 <h3 class="sg-sectionHeading">Alert – <code>.c-icon--alert</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/alert.svg" class="c-icon c-icon--alert"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--alert" spriteId="icons-general-alert" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Basket – <code>.c-icon--basket</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/basket.svg" class="c-icon c-icon--basket"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--basket" spriteId="icons-general-basket" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Collection – <code>.c-icon--collection</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/collection.svg" class="c-icon c-icon--collection"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--collection" spriteId="icons-general-collection" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Collection Bag– <code>.c-icon--collectionBag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/collectionBag.svg" class="c-icon c-icon--collectionBag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--collectionBag" spriteId="icons-general-collectionBag" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Delivery – <code>.c-icon--delivery</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/delivery.svg" class="c-icon c-icon--delivery"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--delivery" spriteId="icons-general-delivery" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Delivery Small – <code>.c-icon--delivery--small</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/delivery.svg" class="c-icon c-icon--delivery c-icon--delivery--small"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--delivery c-icon--delivery--small" spriteId="icons-general-delivery" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Info – <code>.c-icon--info</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/info.svg" class="c-icon c-icon--info"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--info" spriteId="icons-general-info" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Padlock – <code>.c-icon--padlock</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/padlock.svg" class="c-icon c-icon--padlock"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--padlock" spriteId="icons-general-padlock" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Nut Allergy – <code>.c-icon--nutAllergy</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/nutAllergy.svg" class="c-icon c-icon--nutAllergy"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--nutAllergy" spriteId="icons-general-nutAllergy" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Offer – <code>.c-icon--offer</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-icon c-icon--offer"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--offer" spriteId="icons-general-offer" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Offer Small – <code>.c-icon--offer--small</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/offer.svg" class="c-icon c-icon--offer c-icon--offer--small"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--offer c-icon--offer--small" spriteId="icons-general-offer" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Spicy – <code>.c-icon--spicy</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/spicy.svg" class="c-icon c-icon--spicy"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--spicy" spriteId="icons-general-spicy" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Tick – <code>.c-icon--tick</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/tick.svg" class="c-icon c-icon--tick"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--tick" spriteId="icons-general-tick" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Vegetarian – <code>.c-icon--vegetarian</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/general/vegetarian.svg" class="c-icon c-icon--vegetarian"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--vegetarian" spriteId="icons-general-vegetarian" }}
 {{/demo-block }}
 
 
@@ -86,22 +86,22 @@ layout: components
 
 <h3 class="sg-sectionHeading">Eyeglass – <code>.c-icon--eyeglass</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/tools/eyeglass.svg" class="c-icon c-icon--eyeglass"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--eyeglass" spriteId="icons-tools-eyeglass" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Horizontal Sliders – <code>.c-icon--slidersHorizontal</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/tools/slidersHorizontal.svg" class="c-icon c-icon--slidersHorizontal"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--slidersHorizontal" spriteId="icons-tools-slidersHorizontal" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Sort Amount – <code>.c-icon--sortAmount</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/tools/sortAmount.svg" class="c-icon c-icon--sortAmount"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--sortAmount" spriteId="icons-tools-sortAmount" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Map Pin – <code>.c-icon--mapPin</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/tools/mapPin.svg" class="c-icon c-icon--mapPin"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--mapPin" spriteId="icons-tools-mapPin" }}
 {{/demo-block }}
 
 
@@ -109,22 +109,22 @@ layout: components
 
 <h3 class="sg-sectionHeading">Chevron – <code>.c-icon--chevron</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--chevron" spriteId="icons-arrows-chevron" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Chevron Small – <code>.c-icon--chevron--small</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--small"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--chevron c-icon--chevron--small" spriteId="icons-arrows-chevron" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Chevron Up – <code>.c-icon--chevron--up</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--up"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--chevron c-icon--chevron--up" spriteId="icons-arrows-chevron" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Chevron Right – <code>.c-icon--chevron--right</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/arrows/chevron.svg" class="c-icon c-icon--chevron c-icon--chevron--right"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--chevron c-icon--chevron--right" spriteId="icons-arrows-chevron" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Chevron Light – <code>.c-icon--chevron--light</code></h3>
@@ -137,12 +137,12 @@ layout: components
 
 <h3 class="sg-sectionHeading">Amex – <code>.c-icon--amex</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/amex.svg" class="c-icon c-icon--amex"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--amex" spriteId="icons-cards-amex" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Amex Safekey – <code>.c-icon--amex--safekey</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/amex--safekey.svg" class="c-icon c-icon--amex--safekey"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--amex--safekey" spriteId="icons-cards-amex--safekey" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Dankort – <code>.c-icon--dk</code></h3>
@@ -152,37 +152,37 @@ layout: components
 
 <h3 class="sg-sectionHeading">Interac – <code>.c-icon--interac</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/interac.svg" class="c-icon c-icon--interac"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--interac" spriteId="icons-cards-interac" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">MasterCard – <code>.c-icon--mastercard</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/mastercard.svg" class="c-icon c-icon--mastercard"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--mastercard" spriteId="icons-cards-mastercard" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">MasterCard Secure Code – <code>.c-icon--mastercard--securecode</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/mastercard--securecode.svg" class="c-icon c-icon--mastercard--securecode"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--mastercard--securecode" spriteId="icons-cards-mastercard--securecode" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">PayPal – <code>.c-icon--paypal</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/paypal.svg" class="c-icon c-icon--paypal"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--paypal" spriteId="icons-cards-paypal" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Visa – <code>.c-icon--visa</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/visa.svg" class="c-icon c-icon--visa"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--visa" spriteId="icons-cards-visa" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Visa Verified – <code>.c-icon--visa--verified</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/visa--verified.svg" class="c-icon c-icon--visa--verified"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--visa--verified" spriteId="icons-cards-visa--verified" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Maestro – <code>.c-icon--maestro</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/cards/maestro.svg" class="c-icon c-icon--maestro"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--maestro" spriteId="icons-cards-maestro" }}
 {{/demo-block }}
 
 
@@ -190,7 +190,7 @@ layout: components
 
 <h3 class="sg-sectionHeading">Confianza – <code>.c-icon--confianza</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/certificates/confianza.svg" class="c-icon c-icon--confianza"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--confianza" spriteId="icons-certificates-confianza" }}
 {{/demo-block }}
 
 
@@ -198,62 +198,62 @@ layout: components
 
 <h3 class="sg-sectionHeading">Australia – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.au.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.au" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Brazil – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.br.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.br" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Canada – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ca.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.ca" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Denmark – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.dk.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.dk" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Spain – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.es.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.es" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">France – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.fr.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.fr" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">United Kingdom – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.gb.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.gb" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Ireland – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ie.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.ie" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Italy – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.it.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.it" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Norway – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.no.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.no" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">New Zealand – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.nz.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.nz" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Switzerland – <code>.c-icon--flag</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/flags/flag.ch.svg" class="c-icon c-icon--flag"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--flag" spriteId="icons-flags-flag.ch" }}
 {{/demo-block }}
 
 
@@ -261,22 +261,22 @@ layout: components
 
 <h3 class="sg-sectionHeading">Cross – <code>.c-icon--cross</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/operators/cross.svg" class="c-icon c-icon--cross"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--cross" spriteId="icons-operators-cross" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Minus – <code>.c-icon--minus</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/operators/minus.svg" class="c-icon c-icon--minus"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--minus" spriteId="icons-operators-minus" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Plus – <code>.c-icon--plus</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/operators/plus.svg" class="c-icon c-icon--plus"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--plus" spriteId="icons-operators-plus" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Plus – <code>.c-icon--plus--thin</code></h3>
 {{#>demo-block }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/operators/plus--thin.svg" class="c-icon c-icon--plus--thin"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--plus--thin" spriteId="icons-operators-plus--thin" }}
 {{/demo-block }}
 
 
@@ -284,18 +284,55 @@ layout: components
 
 <h3 class="sg-sectionHeading">Star – <code>.c-icon--star</code></h3>
 {{#>demo-block demoVisualCssClass="l-inlined" }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star"}}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--star" spriteId="icons-stars-star--empty" }}
+{{> je-svg-sprite cssClass="c-icon c-icon--star" spriteId="icons-stars-star--filled" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Star Medium – <code>.c-icon--star</code></h3>
 {{#>demo-block demoVisualCssClass="l-inlined" }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star--medium "}}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star--medium "}}
+{{> je-svg-sprite cssClass="c-icon c-icon--star--medium" spriteId="icons-stars-star--empty" }}
+{{> je-svg-sprite cssClass="c-icon c-icon--star--medium" spriteId="icons-stars-star--filled" }}
 {{/demo-block }}
 
 <h3 class="sg-sectionHeading">Star Large – <code>.c-icon--star</code></h3>
 {{#>demo-block demoVisualCssClass="l-inlined" }}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--empty.svg" class="c-icon c-icon--star--large"}}
-{{inlineSVG "@justeat/f-icons/src/img/icons/stars/star--filled.svg" class="c-icon c-icon--star--large"}}
+{{> je-svg-sprite cssClass="c-icon c-icon--star--large" spriteId="icons-stars-star--empty" }}
+{{> je-svg-sprite cssClass="c-icon c-icon--star--large" spriteId="icons-stars-star--filled" }}
+{{/demo-block }}
+
+<h2 class="sg-sectionHeading">Social Icons</h2>
+
+<h3 class="sg-sectionHeading">Facebook – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-facebook" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Google Plus – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-google-plus" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Instagram – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-instagram" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Pinterest – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-pinterest" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">RSS – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-rss" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Twitter – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-twitter" }}
+{{/demo-block }}
+
+<h3 class="sg-sectionHeading">Youtube – <code>.c-icon--social</code></h3>
+{{#>demo-block }}
+{{> je-svg-sprite cssClass="c-icon c-icon--social" spriteId="icons-social-icon-youtube" }}
 {{/demo-block }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"


### PR DESCRIPTION
### Changed
- UI-components icons to be called from svg sprite to improve "Show code" behaviour

Before:
![screen shot 2018-11-05 at 16 39 50](https://user-images.githubusercontent.com/19548183/48012222-70efdd00-e119-11e8-99ef-49bf25e09de1.png)

After:
![screen shot 2018-11-05 at 16 40 08](https://user-images.githubusercontent.com/19548183/48012240-7d743580-e119-11e8-832e-599e57ef55f2.png)

 ### Added
- Social icons to UI icons component examples

![screen shot 2018-11-05 at 16 40 57](https://user-images.githubusercontent.com/19548183/48012287-9977d700-e119-11e8-8bd5-8a8a57bc8acb.png)



