### PR TITLE
2.17.0 - Add docs for f-validate hyrbidMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v2.17.0
 ------------------------------
+*March 21, 2019*
+
+### Added
+- Documentation for `f-validate` `hyrbridMode` configuration option
+
+
+v2.17.0
+------------------------------
 *February 12, 2019*
 
 ### Fixed

--- a/docs/src/templates/pages/styleguide/js-components/validation/index.hbs
+++ b/docs/src/templates/pages/styleguide/js-components/validation/index.hbs
@@ -595,6 +595,15 @@ The properties or attributes that can be defined are as follows:
             <p>By default, `novalidate` is added to a form that is being validated to supress native HTML5 validation.  By setting this option to `true` this attribute is not set and native HTML5 validation will not be supressed.</p>
         </td>
     </tr>
+    <tr>
+        <td><code>hybridMode</code></td>
+        <td>boolean</td>
+        <td><code>true</code> | <code>false</code> (default)</td>
+        <td>
+            <p>When set, both blur (focus lost) and keydown events are bound to each applicable input field.</p>
+            <p>Validation won't run until the user has blurred the input at least once, giving them a chance to enter a valid value before seeing an error.</p>
+        </td>
+    </tr>
     <!-- <tr>
         <td><code>focus</code></td>
         <td>boolean</td>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"


### PR DESCRIPTION
Adds documentation for the `hybridMode` change to the f-validate library. See this PR for more details: https://github.com/justeat/f-validate/pull/31