### PR TITLE
v2.19.0 - Add docs for f-validate event callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v2.17.0
+v2.19.0
+------------------------------
+*March 25, 2019*
+
+### Added
+- Documentation for `f-validate` event callbacks
+
+v2.18.0
 ------------------------------
 *March 21, 2019*
 

--- a/assets/src/scss/base/_layout.scss
+++ b/assets/src/scss/base/_layout.scss
@@ -135,7 +135,8 @@
     margin: spacing(x5) 40px;
 }
 
-td > ul, td > ol {
+td > ul,
+td > ol {
     margin-top: 0;
     margin-bottom: 0;
 }

--- a/assets/src/scss/base/_layout.scss
+++ b/assets/src/scss/base/_layout.scss
@@ -135,9 +135,7 @@
     margin: spacing(x5) 40px;
 }
 
-
-
-
-
-
-
+td > ul, td > ol {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/docs/src/templates/pages/styleguide/js-components/validation/index.hbs
+++ b/docs/src/templates/pages/styleguide/js-components/validation/index.hbs
@@ -698,3 +698,52 @@ To apply multiple rules to the same field, you simply need to add multiple attri
     </div>
 </div>
 {{/demo-block }}
+
+
+<a name="multiple-rules"></a><h2 class="sg-sectionHeading">Callback events</h2>
+
+`f-validate` has a number of events you can hook into. These can be setup by proving a callback function in the options object. Examples of this are show below:
+
+
+```javascript
+new FormValidation(nameOfForm, {
+    onSuccess: function() {
+        console.log("Great success!");
+    },
+    onError: function() {
+        console.log("Form validation failed");
+    },
+    onElementError: function(element, validationType) {
+        console.log(`The ${element.name} element failed the ${validationType} validator`);
+    }
+});
+```
+
+<table class="js-options">
+    <tr>
+        <th>Event</th>
+        <th>Description</th>
+        <th>Parameters</th>
+    </tr>
+    <tr>
+        <td><code>onSuccess</code></td>
+        <td>Fired after the entire form is validated and is considered valid.</td>
+        <td>None</td>
+    </tr>
+    <tr>
+        <td><code>onError</code></td>
+        <td>Fired after the entire form is validated and considered invalid.</td>
+        <td>None</td>
+    </tr>
+    <tr>
+        <td><code>onElementError</code></td>
+        <td>Fired after an individual form element fails a validation check</td>
+        <td>
+            <ul>
+            <li><code>element</code> &ndash; the DOM element that failed the validation checkbox</li>
+            <li><code>validationType</code> &ndash; the name of the validation check that failed</li>
+            </ul>
+        </td>
+    </tr>
+
+</table>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@justeat/f-icons": "1.19.1",
     "@justeat/f-toggle": "1.1.0",
     "@justeat/f-utilities": "0.6.1",
-    "@justeat/f-validate": "1.1.0",
+    "@justeat/f-validate": "1.3.0",
     "@justeat/fozzie": "1.31.0",
     "bezier-easing": "2.1.0",
     "kickoff-grid.css": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "je-global-component-library",
   "title": "Just Eat – Component Library",
   "description": "Component Library and Guidelines for all of Just Eat’s Front-End Platforms",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "homepage": "https://github.com/justeat/global-component-library",
   "contributors": [
     "Github contributors <https://github.com/justeat/global-component-library/graphs/contributors>"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,9 +711,10 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.1.0.tgz#38ac810d87ae356dc1dd06444ddce4797d726b3e"
 
-"@justeat/f-validate@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@justeat/f-validate/-/f-validate-1.1.0.tgz#195b477733c30a81f6dd867c79b159532cd8767a"
+"@justeat/f-validate@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@justeat/f-validate/-/f-validate-1.3.0.tgz#dc30b182e06c11667be0cd9ef49982ccc99a941f"
+  integrity sha512-yQwRS5v4m3BMtSIwMxT6HlrS5zE1ra+Yi5OLXZb2+LSqblDzqK8PGaaKjLKtU8ypH2dC8D2AxPkuqO1gs7N0XA==
   dependencies:
     "@justeat/f-dom" "^0.4.0"
 


### PR DESCRIPTION
Adds docs for the new `elementError` event declared in this PR: https://github.com/justeat/f-validate/pull/32 - there was no docs on the existing events so I added those as well. Let me know if I need to make any changes to the formatting/wording.

## Browsers Tested

- [x] Chrome
- [ ] Safari
- [ ] IE 11
- [x] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)